### PR TITLE
feat: Implement vCard export and style menu items

### DIFF
--- a/app/src/main/java/com/example/deflatam_contactapp/utils/VCardUtils.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/utils/VCardUtils.kt
@@ -1,4 +1,43 @@
 package com.example.deflatam_contactapp.utils
 
+import com.example.deflatam_contactapp.model.Contacto
+
+
+/**
+ * Objeto de utilidad para exportar contactos al formato VCard (.vcf).
+ */
 object VCardUtils {
+
+    /**
+     * Convierte una lista de contactos a un único string en formato VCard.
+     * @param contactos La lista de contactos a exportar.
+     * @return Un String que contiene todos los contactos en formato .vcf.
+     */
+    fun exportToVCard(contactos: List<Contacto>): String {
+        val vcardBuilder = StringBuilder()
+        for (contacto in contactos) {
+            vcardBuilder.append("BEGIN:VCARD\n")
+            vcardBuilder.append("VERSION:3.0\n")
+
+            // Nombre formateado (obligatorio)
+            vcardBuilder.append("FN:${contacto.nombre}\n")
+
+            // Teléfono
+            if (contacto.telefono.isNotBlank()) {
+                vcardBuilder.append("TEL;TYPE=CELL:${contacto.telefono}\n")
+            }
+
+            // Email
+            if (contacto.email != null) {
+                if (contacto.email.isNotBlank()) {
+                    vcardBuilder.append("EMAIL:${contacto.email}\n")
+                }
+            }else{
+                vcardBuilder.append("EMAIL;\n")
+            }
+
+            vcardBuilder.append("END:VCARD\n\n") // Doble salto de línea para separar entradas
+        }
+        return vcardBuilder.toString()
+    }
 }

--- a/app/src/main/java/com/example/deflatam_contactapp/viewmodel/ContactosViewModel.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/viewmodel/ContactosViewModel.kt
@@ -42,6 +42,13 @@ class ContactosViewModel(private val repository: ContactosRepository) : ViewMode
     fun eliminarContacto(contacto: Contacto) = viewModelScope.launch {
         repository.eliminarContacto(contacto)
     }
+
+    /**
+     * Devuelve el valor actual de la lista de contactos.
+     */
+    fun getContactosParaExportar(): List<Contacto>? {
+        return contactos.value
+    }
 }
 
 /**

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,7 +9,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:popupTheme="@style/MiEstiloDePopupMenu">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -3,12 +3,17 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/action_backup"
-        android:title="Crear copia de seguridad"
         android:icon="@drawable/ic_backup"
+        android:title="Crear copia de seguridad"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_restore"
-        android:title="Restaurar copia"
         android:icon="@drawable/ic_restore"
+        android:title="Restaurar copia"
         app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_export_vcard"
+        android:title="Exportar a vCard (.vcf)"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -3,5 +3,17 @@
     <style name="Base.Theme.DefLatam_ContactApp" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your dark theme here. -->
         <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
+        <item name="android:itemTextAppearance">@style/MiEstiloDeTextoDeMenuItem</item>
+    </style>
+
+    <!-- Estilo personalizado para el texto del menú item -->
+    <style name="MiEstiloDeTextoDeMenuItem">
+        <item name="android:textColor">@color/white</item>
+        <!-- <item name="android:textSize">16sp</item> -->
+        <!-- <item name="android:textStyle">bold</item> -->
+    </style>
+    <!-- para un PopupMenu (menú de tres puntos) -->
+    <style name="MiEstiloDePopupMenu" parent="Widget.AppCompat.PopupMenu.Overflow">
+        <item name="android:textColor">@color/white</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,8 +1,18 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Base.Theme.DefLatam_ContactApp" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your light theme here. -->
-        <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
+        <item name="android:itemTextAppearance">@style/MiEstiloDeTextoDeMenuItem</item>
+    </style>
+
+    <!-- Estilo personalizado para el texto del menú item -->
+    <style name="MiEstiloDeTextoDeMenuItem">
+        <item name="android:textColor">@color/black</item>
+        <!-- <item name="android:textSize">16sp</item> -->
+        <!-- <item name="android:textStyle">bold</item> -->
+    </style>
+    <!--para un PopupMenu (menú de tres puntos) -->
+    <style name="MiEstiloDePopupMenu" parent="Widget.AppCompat.PopupMenu.Overflow">
+        <item name="android:textColor">@color/black</item>
     </style>
 
     <style name="Theme.DefLatam_ContactApp" parent="Base.Theme.DefLatam_ContactApp" />


### PR DESCRIPTION
This commit introduces the following changes:

- **vCard Export Functionality:**
    - Added `VCardUtils.kt` to handle the conversion of `Contacto` objects into a VCard (.vcf) formatted string.
    - Implemented `exportToVCard` in `MainActivity` which uses `ActivityResultContracts.CreateDocument` to allow the user to choose a location and filename for the exported .vcf file.
    - Added a new menu item "Exportar a vCard (.vcf)" in `main_menu.xml`.
    - Added `getContactosParaExportar()` in `ContactosViewModel` to retrieve the current list of contacts for export.

- **Menu Item Styling:**
    - Defined custom styles in `themes.xml` and `themes-night.xml` (`MiEstiloDeTextoDeMenuItem` and `MiEstiloDePopupMenu`) to control the text color of menu items and the popup menu in both light and dark themes.
    - Applied the `MiEstiloDePopupMenu` to the `AppBarLayout` in `activity_main.xml` to style the overflow menu.