### PR TITLE
feat: Implement contact import from device

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
         el acceso a archivos al usuario de forma segura.
     -->
 
+    <!--Permiso para leer los contactos del dispositivo  -->
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/deflatam_contactapp/database/ContactoDao.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/database/ContactoDao.kt
@@ -61,5 +61,15 @@ interface ContactoDao {
     /** Method para filtrar contactos por el ID de la categoría ---*/
     @Query("SELECT * FROM contactos WHERE categoria_id = :categoriaId ORDER BY nombre ASC")
     fun getContactosPorCategoria(categoriaId: Int): LiveData<List<Contacto>>
+
+    /** Para inserción en lote */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertarVarios(contactos: List<Contacto>)
+
+
+
+    /**Para obtener una lista estática y comprobar duplicados */
+    @Query("SELECT * FROM contactos")
+    suspend fun getTodosComoLista(): List<Contacto>
 }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -48,6 +48,15 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:listitem="@layout/item_contacto" />
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabAgregar"
         android:layout_width="wrap_content"

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -16,4 +16,9 @@
         android:id="@+id/action_export_vcard"
         android:title="Exportar a vCard (.vcf)"
         app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_import_device"
+        android:title="Importar desde dispositivo"
+        app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
This commit introduces the ability to import contacts from the user's device.

- **Permissions:**
    - Added `READ_CONTACTS` permission to `AndroidManifest.xml`.
- **UI (MainActivity):**
    - Added an "Importar desde dispositivo" option to `main_menu.xml`.
    - Implemented a `requestPermissionLauncher` to handle `READ_CONTACTS` permission requests.
    - Added a `ProgressBar` to `activity_main.xml` to indicate import progress.
    - Observes `estadoImportacion` LiveData from `ContactosViewModel` to show/hide the progress bar and display Toast messages for success or error during import.
    - Added `iniciarImportacionDeContactos` function to check/request permission and trigger import.
- **ViewModel (ContactosViewModel):**
    - Added `EstadoImportacion` enum (`VACIO`, `CARGANDO`, `EXITO`, `ERROR`).
    - Added `_estadoImportacion` LiveData to track and communicate the import status.
    - Added `importarContactosDelDispositivo` function to call the repository method and update import status.
    - Added `resetearEstadoImportacion` to reset the status after completion or error.
- **Repository (ContactosRepository):**
    - Added `importarDesdeDispositivo` suspend function: - Takes `ContentResolver` as a parameter. - Fetches contacts (name and phone number) from the device using `ContactsContract`. - Checks for existing contacts in the local database by phone number to avoid duplicates. - Inserts new contacts into the local database with a default category ID.
- **DAO (ContactoDao):**
    - Added `insertarVarios` suspend function for batch inserting contacts.
    - Added `getTodosComoLista` suspend function to retrieve all contacts as a static list, used for checking duplicates during import.