### PR TITLE
feat: Implement LinkedIn, Website fields and contact actions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,12 +11,17 @@
     <!--Permiso para leer los contactos del dispositivo  -->
     <uses-permission android:name="android.permission.READ_CONTACTS" />
 
+    <uses-feature
+        android:name="android.hardware.telephony"
+        android:required="false" />
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
-        android:label="Contactos App"
+        android:label="DefLatam_ContactApp"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.DefLatam_ContactApp">

--- a/app/src/main/java/com/example/deflatam_contactapp/AgregarContactoActivity.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/AgregarContactoActivity.kt
@@ -68,6 +68,8 @@ class AgregarContactoActivity : AppCompatActivity() {
                     binding.editTextNombre.setText(contacto.nombre)
                     binding.editTextTelefono.setText(contacto.telefono)
                     binding.editTextEmail.setText(contacto.email)
+                    binding.etLinkedin.setText(contacto.linkedin)
+                    binding.etWebsite.setText(contacto.website)
                 } else {
                     Toast.makeText(this, "Contacto no encontrado", Toast.LENGTH_LONG).show()
                     finish()
@@ -110,6 +112,8 @@ class AgregarContactoActivity : AppCompatActivity() {
         val telefono = binding.editTextTelefono.text.toString().trim()
         val email = binding.editTextEmail.text.toString().trim()
         val categoriaId = categoriaSeleccionadaId
+        val linkedin = binding.etLinkedin.text.toString().trim()
+        val website = binding.etWebsite.text.toString().trim()
 
         // Limpia errores previos
         binding.textFieldNombre.error = null
@@ -136,7 +140,9 @@ class AgregarContactoActivity : AppCompatActivity() {
             nombre = nombre,
             telefono = telefono,
             email = email,
-            categoriaId = categoriaId
+            categoriaId = categoriaId,
+            linkedin = linkedin,
+            website = website
         )
 
         if (contactoId == null) {

--- a/app/src/main/java/com/example/deflatam_contactapp/adapter/ContactosAdapter.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/adapter/ContactosAdapter.kt
@@ -8,12 +8,21 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.deflatam_contactapp.databinding.ItemContactoBinding
 import com.example.deflatam_contactapp.model.Contacto
 
+/** interfaz para manejar los eventos de clic en los botones de llamada y mensaje.*/
+interface OnContactActionListener {
+    fun onCallClick(telefono: String)
+    fun onMessageClick(telefono: String)
+    fun onItemClick(contacto: Contacto)
+    fun onLinkedinClick(profile: String)
+    fun onWebsiteClick(url: String)
+}
+
 /**
  * Adaptador para el RecyclerView que muestra la lista de contactos.
  * Utiliza ListAdapter para manejar eficientemente las actualizaciones de la lista.
  * @param onItemClicked Lambda que se ejecuta cuando se hace clic en un contacto.
  */
-class ContactosAdapter(private val onItemClicked: (Contacto) -> Unit) :
+class ContactosAdapter(private val listener: OnContactActionListener) :
     ListAdapter<Contacto, ContactosAdapter.ContactoViewHolder>(DiffCallback) {
 
     /**
@@ -25,12 +34,35 @@ class ContactosAdapter(private val onItemClicked: (Contacto) -> Unit) :
         /**
          * Vincula los datos del contacto a las vistas del layout.
          */
-        fun bind(contacto: Contacto) {
+        fun bind(contacto: Contacto, actionListener: OnContactActionListener) {
             // Usa el data binding para asignar el objeto contacto a la variable del layout
             binding.contacto = contacto
             // Llama a executePendingBindings() para forzar la actualización inmediata del layout.
             // Es una buena práctica para evitar problemas de reciclaje de vistas.
             binding.executePendingBindings()
+
+            //Configurar listeners para los botones y el item completo ---
+            binding.ivCall.setOnClickListener {
+                actionListener.onCallClick(contacto.telefono)
+            }
+
+            binding.ivMessage.setOnClickListener {
+                actionListener.onMessageClick(contacto.telefono)
+            }
+
+            itemView.setOnClickListener {
+                actionListener.onItemClick(contacto)
+            }
+            binding.ivLinkedin.setOnClickListener {
+                if (contacto.linkedin.isNotEmpty()) {
+                    actionListener.onLinkedinClick(contacto.linkedin)
+                }
+            }
+            binding.ivWebsite.setOnClickListener {
+                if (contacto.website.isNotEmpty()) {
+                    actionListener.onWebsiteClick(contacto.website)
+                }
+            }
         }
     }
 
@@ -70,9 +102,6 @@ class ContactosAdapter(private val onItemClicked: (Contacto) -> Unit) :
     override fun onBindViewHolder(holder: ContactoViewHolder, position: Int) {
         val contacto = getItem(position)
         // Configura el listener para el clic en el item
-        holder.itemView.setOnClickListener {
-            onItemClicked(contacto)
-        }
-        holder.bind(contacto)
+        holder.bind(contacto, listener)
     }
 }

--- a/app/src/main/java/com/example/deflatam_contactapp/model/Contacto.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/model/Contacto.kt
@@ -28,5 +28,8 @@ data class Contacto(
     val email: String?,
 
     @ColumnInfo(name = "categoria_id", index = true)
-    val categoriaId: Int?
+    val categoriaId: Int?,
+
+    val linkedin: String = "", // Se guardará solo el path del perfil (ej: "juanperez")
+    val website: String = ""   // Se guardará la URL completa
 )

--- a/app/src/main/res/drawable/ic_call.xml
+++ b/app/src/main/res/drawable/ic_call.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6.62,10.79C8.06,13.62 10.38,15.94 13.21,17.38L15.41,15.18C15.69,14.9 16.08,14.82 16.43,14.93C17.55,15.3 18.75,15.5 20,15.5C20.55,15.5 21,15.95 21,16.5V20C21,20.55 20.55,21 20,21C10.61,21 3,13.39 3,4C3,3.45 3.45,3 4,3H7.5C8.05,3 8.5,3.45 8.5,4C8.5,5.25 8.7,6.45 9.07,7.57C9.18,7.92 9.1,8.31 8.82,8.59L6.62,10.79Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_link.xml
+++ b/app/src/main/res/drawable/ic_link.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3.9,12c0,-1.71 1.39,-3.1 3.1,-3.1h4V7H7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h4v-1.9H7c-1.71,0 -3.1,-1.39 -3.1,-3.1zM8,13h8v-2H8v2zM17,7h-4v1.9h4c1.71,0 3.1,1.39 3.1,3.1s-1.39,3.1 -3.1,3.1h-4V17h4c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_linkedin.xml
+++ b/app/src/main/res/drawable/ic_linkedin.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#0077B5"
+        android:pathData="M19,3a2,2 0,0 1,2 2v14a2,2 0,0 1,-2 2H5a2,2 0,0 1,-2 -2V5a2,2 0,0 1,2 -2h14m-10,15h3V11h-3v7zM7,8a1.5,1.5 0,1 0,0 3,1.5 1.5,0 0,0 0,-3zM16,18h3v-4.7c0,-2.5 -1.5,-3.3 -2.8,-3.3c-1.3,0 -2.2,1.1 -2.2,1.1V11h-3v7h3v-3.5c0,-0.8 0.5,-1.5 1.5,-1.5s1.5,0.7 1.5,1.5V18z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_message.xml
+++ b/app/src/main/res/drawable/ic_message.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,2H4C2.9,2 2,2.9 2,4v18l4,-4h14c1.1,0 2,-0.9 2,-2V4C22,2.9 21.1,2 20,2zM6,9h12v2H6V9zM14,14H6v-2h8V14zM18,8H6V6h12V8z"/>
+</vector>

--- a/app/src/main/res/layout/activity_agregar_contacto.xml
+++ b/app/src/main/res/layout/activity_agregar_contacto.xml
@@ -61,6 +61,31 @@
             android:inputType="textEmailAddress" />
     </com.google.android.material.textfield.TextInputLayout>
 
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="Perfil de LinkedIn (ej: juanperez) (Opcional)">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_linkedin"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="Sitio Web (URL completa) (Opcional)">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_website"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textUri"/>
+    </com.google.android.material.textfield.TextInputLayout>
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -75,6 +100,8 @@
         android:dropDownVerticalOffset="8dp"
         android:dropDownWidth="wrap_content"
         />
+
+
     <Button
         android:id="@+id/buttonGuardar"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,12 +41,38 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerViewContactos"
+    <!-- Usar NestedScrollView para que RecyclerView y TextView se desplacen juntos -->
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        tools:listitem="@layout/item_contacto" />
+        android:fillViewport="true"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerViewContactos"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false"
+                tools:itemCount="5"
+                tools:listitem="@layout/item_contacto" />
+
+            <TextView
+                android:id="@+id/textViewAvisoComoBorrarContactos"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
+                android:padding="8dp"
+                android:text="Para borrar un contacto. Deslice izquierda o derecha."
+                android:textSize="16sp" />
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
 
     <ProgressBar
         android:id="@+id/progressBar"

--- a/app/src/main/res/layout/item_contacto.xml
+++ b/app/src/main/res/layout/item_contacto.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -7,6 +8,10 @@
         <variable
             name="contacto"
             type="com.example.deflatam_contactapp.model.Contacto" />
+
+        <variable
+            name="view"
+            type="android.view.View" />
     </data>
 
     <androidx.cardview.widget.CardView
@@ -14,34 +19,96 @@
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
         android:elevation="4dp"
-        android:radius="8dp"
-        android:padding="16dp">
+        android:padding="16dp"
+        android:radius="8dp">
 
-        <LinearLayout
+        <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="?android:attr/selectableItemBackground"
-            android:orientation="vertical"
             android:padding="16dp">
 
-            <TextView
-                android:id="@+id/textViewNombre"
+            <LinearLayout
+                android:id="@+id/info_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@{contacto.nombre}"
-                android:textAppearance="?attr/textAppearanceListItem"
-                android:textSize="18sp"
-                tools:text="Nombre del Contacto" />
+                android:layout_alignParentStart="true"
+                android:layout_toStartOf="@+id/actions_container"
+                android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/textViewTelefono"
-                android:layout_width="match_parent"
+                <TextView
+                    android:id="@+id/tv_nombre"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@{contacto.nombre}"
+                    android:textAppearance="?attr/textAppearanceListItem"
+                    tools:text="Nombre Apellido" />
+
+                <TextView
+                    android:id="@+id/tv_telefono"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@{contacto.telefono}"
+                    android:textAppearance="?attr/textAppearanceListItemSecondary"
+                    tools:text="123456789" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:orientation="horizontal">
+
+                    <ImageView
+                        android:id="@+id/iv_linkedin"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginStart="16dp"
+                        android:visibility="@{contacto.linkedin.empty  ? view.GONE : view.VISIBLE}"
+                        app:srcCompat="@drawable/ic_linkedin"
+                        tools:visibility="visible" />
+
+                    <ImageView
+                        android:id="@+id/iv_website"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginStart="16dp"
+                        android:visibility="@{contacto.website.empty ? view.GONE : view.VISIBLE}"
+                        app:srcCompat="@drawable/ic_link"
+                        tools:visibility="visible" />
+                </LinearLayout>
+            </LinearLayout>
+
+
+            <!--Contenedor para los botones de llamada y mensaje  -->
+            <LinearLayout
+                android:id="@+id/actions_container"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{contacto.telefono}"
-                android:textAppearance="?attr/textAppearanceListItemSecondary"
-                tools:text="123-456-7890" />
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:orientation="horizontal">
 
-        </LinearLayout>
+                <ImageView
+                    android:id="@+id/iv_call"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:contentDescription="Llamar al contacto"
+                    android:padding="8dp"
+                    android:src="@drawable/ic_call" />
+
+                <ImageView
+                    android:id="@+id/iv_message"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_marginStart="8dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:contentDescription="Enviar mensaje al contacto"
+                    android:padding="8dp"
+                    android:src="@drawable/ic_message" />
+            </LinearLayout>
+
+        </RelativeLayout>
+
     </androidx.cardview.widget.CardView>
 
 </layout>


### PR DESCRIPTION
This commit introduces several enhancements:

- **Contact Model & Form:**
    - Added `linkedin` and `website` fields to the `Contacto` model.
    - Updated `AgregarContactoActivity` to include input fields for LinkedIn profile and website URL, and handle saving these new fields.
- **Contact Item UI & Actions:**
    - Revamped `item_contacto.xml` to include: - Buttons for Call and Message actions. - Icons for LinkedIn and Website, visible only if the contact has these details.
    - Implemented `OnContactActionListener` interface in `ContactosAdapter` and `MainActivity` to handle clicks on Call, Message, LinkedIn, and Website.
    - Added new icons: `ic_call.xml`, `ic_message.xml`, `ic_linkedin.xml`, `ic_link.xml`.
- **MainActivity:**
    - Implemented call functionality, including requesting `CALL_PHONE` permission.
    - Implemented SMS functionality using `Intent.ACTION_SENDTO`.
    - Implemented opening LinkedIn profiles and websites in a browser.
    - Added a `TextView` below the contact list in `activity_main.xml` to inform users how to delete contacts (swipe).
- **Manifest:**
    - Added `CALL_PHONE` permission and declared `android.hardware.telephony` feature as not required.
    - Changed app label to "DefLatam_ContactApp".
- **UX:**
    - Removed the "UNDO" action from the Snackbar when deleting a contact to simplify.
    - Ensured website URLs are prefixed with "http://" or "https://" before opening.