### PR TITLE
feat: Implement group management for contacts

### DIFF
--- a/app/src/main/java/com/example/deflatam_contactapp/MainActivity.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/MainActivity.kt
@@ -12,9 +12,7 @@ import android.view.View
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.lifecycleScope
@@ -46,7 +44,7 @@ class MainActivity : AppCompatActivity(), OnContactActionListener {
     private val viewModel: ContactosViewModel by viewModels {
         // Inicializa el ViewModel usando la fábrica para inyectar el repositorio.
         val database = ContactosDatabase.getDatabase(context = applicationContext, coroutineScope = lifecycleScope)
-        val repository = ContactosRepository(database.contactoDao(), database.categoriaDao())
+        val repository = ContactosRepository(database.contactoDao(), database.categoriaDao(), database.grupoDao())
         ContactosViewModelFactory(repository)
     }
 
@@ -194,7 +192,7 @@ class MainActivity : AppCompatActivity(), OnContactActionListener {
         ItemTouchHelper(itemTouchHelperCallback).attachToRecyclerView(binding.recyclerViewContactos)
     }
 
-    // --- NUEVO: Implementación de los métodos de la interfaz ---
+    // Implementación de los métodos de la interfaz
     override fun onCallClick(telefono: String) {
         numeroParaLlamar = telefono
         when {
@@ -245,7 +243,7 @@ class MainActivity : AppCompatActivity(), OnContactActionListener {
         openUrl(properUrl)
     }
 
-    // --- NUEVO: Función auxiliar para realizar la llamada ---
+    //Función auxiliar para realizar la llamada ---
     private fun realizarLlamada(telefono: String) {
         try {
             val intent = Intent(Intent.ACTION_CALL, Uri.parse("tel:$telefono"))

--- a/app/src/main/java/com/example/deflatam_contactapp/database/ContactoConGrupos.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/database/ContactoConGrupos.kt
@@ -1,0 +1,25 @@
+package com.example.deflatam_contactapp.database
+
+import androidx.room.Embedded
+import androidx.room.Junction
+import androidx.room.Relation
+import com.example.deflatam_contactapp.model.Contacto
+import com.example.deflatam_contactapp.model.Grupo
+
+/**
+ * Representa un Contacto y la lista de Grupos a los que pertenece.
+ */
+data class ContactoConGrupos(
+    @Embedded val contacto: Contacto,
+    @Relation(
+        parentColumn = "id",
+        entity = Grupo::class,
+        entityColumn = "id",
+        associateBy = Junction(
+            value = ContactoGrupoCrossRef::class,
+            parentColumn = "contactoId",
+            entityColumn = "grupoId"
+        )
+    )
+    val grupos: List<Grupo>
+)

--- a/app/src/main/java/com/example/deflatam_contactapp/database/ContactoDao.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/database/ContactoDao.kt
@@ -20,7 +20,7 @@ interface ContactoDao {
      * Inserta un nuevo contacto en la base de datos.
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(contacto: Contacto)
+    suspend fun insert(contacto: Contacto) : Long
 
     /**
      * Actualiza un contacto existente en la base de datos.

--- a/app/src/main/java/com/example/deflatam_contactapp/database/ContactoGrupoCrossRef.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/database/ContactoGrupoCrossRef.kt
@@ -1,0 +1,12 @@
+package com.example.deflatam_contactapp.database
+
+import androidx.room.Entity
+
+/**
+ * Tabla de unión para la relación muchos a muchos entre Contacto y Grupo.
+ */
+@Entity(tableName = "contacto_grupo_cross_ref", primaryKeys = ["contactoId", "grupoId"])
+data class ContactoGrupoCrossRef(
+    val contactoId: Int,
+    val grupoId: Int
+)

--- a/app/src/main/java/com/example/deflatam_contactapp/database/GrupoDao.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/database/GrupoDao.kt
@@ -1,56 +1,35 @@
 package com.example.deflatam_contactapp.database
 
-/*
-
 import androidx.lifecycle.LiveData
-import androidx.room.*
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.example.deflatam_contactapp.model.Grupo
 
-
+/** Objeto de Acceso a Datos (DAO) para la entidad Grupo. */
 @Dao
 interface GrupoDao {
 
-    // CRUD para grupos
-    @Insert
-    suspend fun insertarGrupo(grupo: Grupo)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun crearGrupo(grupo: Grupo)
 
-    @Update
-    suspend fun actualizarGrupo(grupo: Grupo)
+    @Query("SELECT * FROM grupos_table ORDER BY nombre ASC")
+    fun getTodosLosGrupos(): LiveData<List<Grupo>>
 
-    @Delete
-    suspend fun eliminarGrupo(grupo: Grupo)
-
-    @Query("SELECT * FROM grupos ORDER BY nombre ASC")
-    fun obtenerGrupos(): LiveData<List<Grupo>>
-
-    // Relación contacto-grupo
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertarContactoGrupoCrossRef(ref: ContactoGrupoCrossRef)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun addContactoAGrupo(crossRef: ContactoGrupoCrossRef)
 
     @Delete
-    suspend fun eliminarContactoGrupoCrossRef(ref: ContactoGrupoCrossRef)
+    suspend fun removeContactoDeGrupo(crossRef: ContactoGrupoCrossRef)
 
-    // Obtener grupo con sus contactos
-    @Transaction
-    @Query("SELECT * FROM grupos WHERE id = :grupoId")
-    fun obtenerGrupoConContactos(grupoId: Int): LiveData<GrupoConContactos>
-
-    // Obtener todos los grupos con sus contactos
-    @Transaction
-    @Query("SELECT * FROM grupos ORDER BY nombre ASC")
-    fun obtenerTodosLosGruposConContactos(): LiveData<List<GrupoConContactos>>
-
-    // Obtener contacto con sus grupos (relación inversa)
     @Transaction
     @Query("SELECT * FROM contactos WHERE id = :contactoId")
-    fun obtenerContactoConGrupos(contactoId: Int): LiveData<ContactoConGrupos>
+    fun getGruposDeUnContacto(contactoId: Int): LiveData<ContactoConGrupos>
 
-    // Consultas adicionales útiles
-    @Query("SELECT COUNT(*) FROM contactos c INNER JOIN ContactoGrupoCrossRef cgr ON c.id = cgr.contactoId WHERE cgr.grupoId = :grupoId")
-    suspend fun contarContactosEnGrupo(grupoId: Int): Int
+    @Query("DELETE FROM grupos_table WHERE id = :contactoId")
+    fun limpiarGruposDeContacto(contactoId: Int)
 
-    @Query("SELECT * FROM contactos c INNER JOIN ContactoGrupoCrossRef cgr ON c.id = cgr.contactoId WHERE cgr.grupoId = :grupoId")
-    fun obtenerContactosDeGrupo(grupoId: Int): LiveData<List<Contacto>>
-
-    @Query("SELECT * FROM grupos g INNER JOIN ContactoGrupoCrossRef cgr ON g.id = cgr.grupoId WHERE cgr.contactoId = :contactoId")
-    fun obtenerGruposDeContacto(contactoId: Int): LiveData<List<Grupo>>
-}*/
+}

--- a/app/src/main/java/com/example/deflatam_contactapp/model/Grupo.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/model/Grupo.kt
@@ -1,0 +1,14 @@
+package com.example.deflatam_contactapp.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Representa un grupo de contactos.
+ */
+@Entity(tableName = "grupos_table")
+data class Grupo(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val nombre: String
+)

--- a/app/src/main/java/com/example/deflatam_contactapp/repository/ContactosRepository.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/repository/ContactosRepository.kt
@@ -5,9 +5,13 @@ import android.content.ContentResolver
 import android.provider.ContactsContract
 import androidx.lifecycle.LiveData
 import com.example.deflatam_contactapp.database.CategoriaDao
+import com.example.deflatam_contactapp.database.ContactoConGrupos
 import com.example.deflatam_contactapp.database.ContactoDao
+import com.example.deflatam_contactapp.database.ContactoGrupoCrossRef
+import com.example.deflatam_contactapp.database.GrupoDao
 import com.example.deflatam_contactapp.model.Categoria
 import com.example.deflatam_contactapp.model.Contacto
+import com.example.deflatam_contactapp.model.Grupo
 
 
 /**
@@ -15,7 +19,8 @@ import com.example.deflatam_contactapp.model.Contacto
  */
 class ContactosRepository(
     private val contactoDao: ContactoDao,
-    private val categoriaDao: CategoriaDao
+    private val categoriaDao: CategoriaDao,
+    private val grupoDao: GrupoDao
 ) {
 
     /**
@@ -38,8 +43,8 @@ class ContactosRepository(
     /**
      * Inserta un nuevo contacto en la base de datos.
      */
-    suspend fun insertarContacto(contacto: Contacto) {
-        contactoDao.insert(contacto)
+    suspend fun insertarContacto(contacto: Contacto): Long {
+        return contactoDao.insert(contacto)
     }
 
     /**
@@ -125,6 +130,34 @@ class ContactosRepository(
 
         if (nuevosContactos.isNotEmpty()) {
             contactoDao.insertarVarios(nuevosContactos)
+        }
+    }
+
+    /** Obtiene todos los grupos. */
+    val todosLosGrupos: LiveData<List<Grupo>> = grupoDao.getTodosLosGrupos()
+
+    /** Crea un nuevo grupo. */
+    suspend fun crearGrupo(grupo: Grupo) {
+        grupoDao.crearGrupo(grupo)
+    }
+
+    /** Obtiene los grupos de un contacto. */
+    fun getGruposDeUnContacto(contactoId: Int): LiveData<ContactoConGrupos> {
+        return grupoDao.getGruposDeUnContacto(contactoId)
+    }
+
+    /**
+     * Actualiza las asociaciones de un contacto a los grupos.
+     * Borra las antiguas y añade las nuevas.
+     */
+    suspend fun actualizarGruposDeContacto(contactoId: Int, nuevosGrupoIds: List<Int>) {
+
+        // Limpiamos referencias viejas
+        //grupoDao.limpiarGruposDeContacto(contactoId)
+
+        // Añadimos las nuevas
+        nuevosGrupoIds.forEach { grupoId ->
+            grupoDao.addContactoAGrupo(ContactoGrupoCrossRef(contactoId, grupoId))
         }
     }
 

--- a/app/src/main/java/com/example/deflatam_contactapp/utils/VCardUtils.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/utils/VCardUtils.kt
@@ -36,6 +36,20 @@ object VCardUtils {
                 vcardBuilder.append("EMAIL;\n")
             }
 
+            //LInkedin
+            if (contacto.linkedin != null) {
+                vcardBuilder.append("Linkedin:https://www.linkedin.com/in/${contacto.linkedin}\n")
+            }else{
+                vcardBuilder.append("Linkedin;\n")
+            }
+
+            //Web site
+            if (contacto.website != null){
+                vcardBuilder.append("website:${contacto.website}\n")
+            }else{
+                vcardBuilder.append("website;\n")
+            }
+
             vcardBuilder.append("END:VCARD\n\n") // Doble salto de línea para separar entradas
         }
         return vcardBuilder.toString()

--- a/app/src/main/java/com/example/deflatam_contactapp/viewmodel/AgregarContactoViewModel.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/viewmodel/AgregarContactoViewModel.kt
@@ -6,8 +6,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.example.deflatam_contactapp.database.ContactoConGrupos
 import com.example.deflatam_contactapp.model.Categoria
 import com.example.deflatam_contactapp.model.Contacto
+import com.example.deflatam_contactapp.model.Grupo
 import com.example.deflatam_contactapp.repository.ContactosRepository
 import kotlinx.coroutines.launch
 
@@ -17,12 +19,20 @@ import kotlinx.coroutines.launch
  */
 class AgregarContactoViewModel(private val repository: ContactosRepository) : ViewModel() {
 
+    val todosLosGrupos: LiveData<List<Grupo>> = repository.todosLosGrupos
+
+    var gruposDelContacto: LiveData<ContactoConGrupos> = MutableLiveData()
+
     /**
      * LiveData que expone la lista de todas las categorías disponibles.
      */
     val todasLasCategorias: LiveData<List<Categoria>> = repository.todasLasCategorias
 
+    /**
+     * LiveData para observar el resultado de la operación de guardado.
+     */
     private val _estadoGuardado = MutableLiveData<Result<Unit>>()
+
     /**
      * LiveData para observar el resultado de la operación de guardado.
      */
@@ -54,10 +64,38 @@ class AgregarContactoViewModel(private val repository: ContactosRepository) : Vi
     }
 
     /**
-     * Obtiene un contacto por su ID.
+     * Obtiene un contacto por su ID. Y actualiza los grupos a los que pertenece el contacto.
      */
     fun getContactoById(contactoId: Int): LiveData<Contacto> {
+        gruposDelContacto = repository.getGruposDeUnContacto(contactoId)
         return repository.getContactoById(contactoId)
+    }
+
+    /** La función de guardado ahora necesita el ID del contacto guardado
+    *y la lista de grupos a los que asociarlo.*/
+    fun guardarContactoYAsociarGrupos(contacto: Contacto, grupoIds: List<Int>) = viewModelScope.launch {
+        try {
+            // Si el contacto es nuevo, insertamos y obtenemos su ID
+            if (contacto.id == 0) {
+                val nuevoId =
+                    repository.insertarContacto(contacto) // Necesitamos que el repo devuelva el ID
+                repository.actualizarGruposDeContacto(nuevoId.toInt(), grupoIds)
+                _estadoGuardado.postValue(Result.success(Unit))
+            } else { // Si el contacto ya existe, actualizamos
+                repository.actualizarContacto(contacto)
+                repository.actualizarGruposDeContacto(contacto.id, grupoIds)
+                _estadoGuardado.postValue(Result.success(Unit))
+            }
+        }catch(e: Exception) {
+            _estadoGuardado.postValue(Result.failure(e))
+        }
+    }
+
+    fun crearNuevoGrupo(nombreGrupo: String) = viewModelScope.launch {
+        if (nombreGrupo.isNotBlank()) {
+            val nuevoGrupo = Grupo(nombre = nombreGrupo)
+            repository.crearGrupo(nuevoGrupo)
+        }
     }
 }
 

--- a/app/src/main/res/layout/activity_agregar_contacto.xml
+++ b/app/src/main/res/layout/activity_agregar_contacto.xml
@@ -46,6 +46,28 @@
             android:inputType="phone" />
     </com.google.android.material.textfield.TextInputLayout>
 
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Grupos"
+        android:textAppearance="?attr/textAppearanceLabelLarge" />
+
+    <TextView
+        android:id="@+id/tv_grupos_seleccionados"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        tools:text="Familia, Trabajo" />
+
+    <Button
+        android:id="@+id/btn_seleccionar_grupos"
+        style="?attr/materialButtonOutlinedStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Seleccionar Grupos" />
+
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/textFieldEmail"
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"


### PR DESCRIPTION
This commit introduces functionality to manage groups and associate contacts with them.

- **Data Layer:**
    - Added `Grupo` entity and `GrupoDao` for group operations.
    - Implemented `ContactoGrupoCrossRef` for many-to-many relationship between contacts and groups.
    - Added `ContactoConGrupos` to represent a contact with its associated groups.
    - Modified `ContactosDatabase` to include `Grupo` and `ContactoGrupoCrossRef` entities and populate default groups.
    - `ContactoDao.insert` now returns the ID of the inserted contact.
    - `ContactosRepository` now handles group-related operations:
        - `todosLosGrupos`: LiveData for all groups.
        - `crearGrupo`: Creates a new group. - `getGruposDeUnContacto`: LiveData for groups of a specific contact. - `actualizarGruposDeContacto`: Updates group associations for a contact.

- **ViewModel Layer (`AgregarContactoViewModel`):**
    - Exposes `todosLosGrupos` and `gruposDelContacto` LiveData.
    - Added `guardarContactoYAsociarGrupos` to save a contact and its group associations.
    - Added `crearNuevoGrupo` to create new groups from the UI.

- **UI Layer (`AgregarContactoActivity`):**
    - Added UI elements for group selection: - `TextView` to display selected groups (`tv_grupos_seleccionados`). - `Button` to open group selection dialog (`btn_seleccionar_grupos`).
    - Implemented `mostrarDialogoSeleccionGrupos` to display a multi-choice dialog for group selection.
    - Implemented `mostrarDialogoCrearGrupo` to allow creating new groups from the selection dialog.
    - Updated contact saving logic to use `guardarContactoYAsociarGrupos`.
    - Spinner for categories now uses `android.R.layout.simple_spinner_item`.

- **VCardUtils:**
    - Added Linkedin and Website fields to VCard generation.

- **Minor changes:**
    - Updated `MainActivity` to pass `grupoDao` to `ContactosRepository`.
    - Cleaned up `GrupoDao` interface.