### PR TITLE
Fix: Adjust UI for system bars and clean up XML

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_24" default="true" project-jdk-name="24" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/example/deflatam_contactapp/MainActivity.kt
+++ b/app/src/main/java/com/example/deflatam_contactapp/MainActivity.kt
@@ -14,6 +14,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -124,9 +128,27 @@ class MainActivity : AppCompatActivity(), OnContactActionListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setSupportActionBar(binding.toolbar)
+
+        val mainContainer = findViewById<View>(R.id.activity_main) // Obtén tu contenedor principal
+
+        ViewCompat.setOnApplyWindowInsetsListener(mainContainer) { view, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+            // Aplica padding a tu contenedor principal para evitar las barras del sistema
+            view.updatePadding(
+                left = insets.left,
+                top = insets.top,
+                right = insets.right,
+                bottom = insets.bottom
+            )
+
+            // Devuelve los insets consumidos o los originales si no los consumes completamente
+            WindowInsetsCompat.CONSUMED // O puedes devolver windowInsets si otras vistas también necesitan procesarlos
+        }
 
         // Observar el estado de la importacion
         viewModel.estadoImportacion.observe(this) { estado ->

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".MainActivity"
+    android:id="@+id/activity_main">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
This commit introduces changes to ensure the app's UI correctly handles system bars (like the status bar and navigation bar) and removes an unnecessary XML declaration.

- **MainActivity.kt:**
    - Enabled edge-to-edge display by calling `WindowCompat.setDecorFitsSystemWindows(window, false)`.
    - Added an `OnApplyWindowInsetsListener` to the main container (`activity_main`).
    - The listener updates the padding of the main container to account for system bar insets, preventing UI elements from overlapping with them.
- **activity_main.xml:**
    - Added an `android:id="@+id/activity_main"` to the root ConstraintLayout to allow referencing it in `MainActivity.kt` for applying window insets.
- **.idea/misc.xml:**
    - Removed the `<?xml version="1.0" encoding="UTF-8"?>` declaration as it's often not strictly necessary for this IDE configuration file.